### PR TITLE
Add Warp terminal support

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -345,6 +345,13 @@ def test_windows_terminal_exports_parse() -> None:
         assert data["background"].startswith("#")
 
 
+def test_warp_exports_cover_both_theme_modes() -> None:
+    for slug in SLUGS:
+        theme = (ROOT / f"themes/terminal/warp/{slug}.yaml").read_text()
+        assert f"details: {'lighter' if slug.endswith('-light') else 'darker'}" in theme
+        assert theme.count("    ") == 16
+
+
 def test_iterm_exports_parse() -> None:
     for slug in SLUGS:
         data = plistlib.loads((ROOT / f"themes/terminal/iterm2/{slug}.itermcolors").read_bytes())

--- a/themes/terminal/README.md
+++ b/themes/terminal/README.md
@@ -1,6 +1,6 @@
 # Terminal themes
 
-Generated imports are provided for Alacritty, iTerm2, and Windows Terminal. Each
+Generated imports are provided for Alacritty, iTerm2, Warp, and Windows Terminal. Each
 uses the family’s primary background and foreground. Alternative surfaces live in
 the JSON manifest, generated CSS, and Python `surfaces()` API; substitute them when a
 different canvas is needed. Terminal formats themselves expose only their native primary
@@ -24,6 +24,11 @@ Restart Alacritty or reload its configuration.
 
 Open **Settings → Profiles → Colors → Color Presets… → Import…**, choose a
 `.itermcolors` file, then select the imported preset from **Color Presets…**.
+
+### Warp
+
+Copy one generated YAML file into `~/.warp/themes`, then select it from
+**Settings → Appearance → Current Theme**.
 
 ### Windows Terminal
 

--- a/themes/terminal/warp/1200k-dark.yaml
+++ b/themes/terminal/warp/1200k-dark.yaml
@@ -1,0 +1,24 @@
+name: 1200K Dark
+accent: '#DDCD81'
+background: '#060302'
+details: darker
+foreground: '#FFE5BD'
+terminal_colors:
+  bright:
+    black: '#FFE5BD'
+    blue: '#DDCD81'
+    cyan: '#C9FFB4'
+    green: '#C9FFB4'
+    magenta: '#F29298'
+    red: '#F29298'
+    white: '#FFE5BD'
+    yellow: '#DDCD81'
+  normal:
+    black: '#130E0B'
+    blue: '#DDCD81'
+    cyan: '#C9FFB4'
+    green: '#C9FFB4'
+    magenta: '#F29298'
+    red: '#F29298'
+    white: '#FFE5BD'
+    yellow: '#DDCD81'

--- a/themes/terminal/warp/2000k-dark.yaml
+++ b/themes/terminal/warp/2000k-dark.yaml
@@ -1,0 +1,24 @@
+name: 2000K Dark
+accent: '#A7D1FB'
+background: '#070504'
+details: darker
+foreground: '#EED5AE'
+terminal_colors:
+  bright:
+    black: '#EED5AE'
+    blue: '#A7D1FB'
+    cyan: '#74E5C0'
+    green: '#74E5C0'
+    magenta: '#EC8B96'
+    red: '#EC8B96'
+    white: '#EED5AE'
+    yellow: '#C39C49'
+  normal:
+    black: '#15110E'
+    blue: '#A7D1FB'
+    cyan: '#74E5C0'
+    green: '#74E5C0'
+    magenta: '#EC8B96'
+    red: '#EC8B96'
+    white: '#EED5AE'
+    yellow: '#C39C49'

--- a/themes/terminal/warp/3400k-dark.yaml
+++ b/themes/terminal/warp/3400k-dark.yaml
@@ -1,0 +1,24 @@
+name: 3400K Dark
+accent: '#B4C6F7'
+background: '#090807'
+details: darker
+foreground: '#DDD0B2'
+terminal_colors:
+  bright:
+    black: '#DDD0B2'
+    blue: '#B4C6F7'
+    cyan: '#70DBD8'
+    green: '#7EB798'
+    magenta: '#D895C2'
+    red: '#F5AD9A'
+    white: '#DDD0B2'
+    yellow: '#CA9246'
+  normal:
+    black: '#181612'
+    blue: '#B4C6F7'
+    cyan: '#70DBD8'
+    green: '#7EB798'
+    magenta: '#D895C2'
+    red: '#F5AD9A'
+    white: '#DDD0B2'
+    yellow: '#CA9246'

--- a/themes/terminal/warp/3400k-light.yaml
+++ b/themes/terminal/warp/3400k-light.yaml
@@ -1,0 +1,24 @@
+name: 3400K Light
+accent: '#162252'
+background: '#FFF7D6'
+details: lighter
+foreground: '#342F2C'
+terminal_colors:
+  bright:
+    black: '#342F2C'
+    blue: '#162252'
+    cyan: '#00766E'
+    green: '#174213'
+    magenta: '#643563'
+    red: '#470D05'
+    white: '#342F2C'
+    yellow: '#894C03'
+  normal:
+    black: '#342F2C'
+    blue: '#162252'
+    cyan: '#00766E'
+    green: '#174213'
+    magenta: '#643563'
+    red: '#470D05'
+    white: '#342F2C'
+    yellow: '#894C03'

--- a/tools/build_all.py
+++ b/tools/build_all.py
@@ -134,6 +134,23 @@ def _windows_terminal(family: dict) -> str:
     return json.dumps(payload, indent=2) + "\n"
 
 
+def _warp(family: dict) -> str:
+    terminal = family["terminal"]
+    lines = [
+        f"name: {family['name']}",
+        f"accent: '{terminal['blue']}'",
+        f"background: '{family['surfaces']['bg_0']}'",
+        f"details: {'darker' if family['mode'] == 'dark' else 'lighter'}",
+        f"foreground: '{family['surfaces']['fg_0']}'",
+        "terminal_colors:",
+    ]
+    for group, names in (("bright", ANSI_NAMES[8:]), ("normal", ANSI_NAMES[:8])):
+        lines.append(f"  {group}:")
+        for name in sorted(names):
+            lines.append(f"    {name.removeprefix('bright_')}: '{terminal[name]}'")
+    return "\n".join(lines) + "\n"
+
+
 def _iterm_color(value: str) -> dict:
     rgb = hex_to_srgb(value)
     return {
@@ -344,7 +361,7 @@ def build(destination: Path) -> None:
     _write(destination / "palettes/ember.css", _css(manifest))
     terminal_readme = """# Terminal themes
 
-Generated imports are provided for Alacritty, iTerm2, and Windows Terminal. Each
+Generated imports are provided for Alacritty, iTerm2, Warp, and Windows Terminal. Each
 uses the family’s primary background and foreground. Alternative surfaces live in
 the JSON manifest, generated CSS, and Python `surfaces()` API; substitute them when a
 different canvas is needed. Terminal formats themselves expose only their native primary
@@ -368,6 +385,11 @@ Restart Alacritty or reload its configuration.
 
 Open **Settings → Profiles → Colors → Color Presets… → Import…**, choose a
 `.itermcolors` file, then select the imported preset from **Color Presets…**.
+
+### Warp
+
+Copy one generated YAML file into `~/.warp/themes`, then select it from
+**Settings → Appearance → Current Theme**.
 
 ### Windows Terminal
 
@@ -399,6 +421,7 @@ pairing under `metrics.shifted_text_contrast` in the JSON manifest.
             destination / f"themes/terminal/windows-terminal/{slug}.json", _windows_terminal(family)
         )
         _write(destination / f"themes/terminal/iterm2/{slug}.itermcolors", _iterm(family))
+        _write(destination / f"themes/terminal/warp/{slug}.yaml", _warp(family))
         profile = manifest["profiles"][family["profile"]]
         _write(destination / f"docs/swatches/{slug}.svg", _family_svg(family, profile, chrome))
 
@@ -445,6 +468,7 @@ def check() -> int:
                     Path(f"docs/swatches/{slug}.svg"),
                     Path(f"themes/terminal/alacritty/{slug}.toml"),
                     Path(f"themes/terminal/iterm2/{slug}.itermcolors"),
+                    Path(f"themes/terminal/warp/{slug}.yaml"),
                     Path(f"themes/terminal/windows-terminal/{slug}.json"),
                 )
             )


### PR DESCRIPTION
Adds build support for Warp's theme format.

## Screenshots

#### 3400K Light

<img width="3482" height="1896" alt="CleanShot 2026-08-15 at 07 09 08@2x" src="https://github.com/user-attachments/assets/ce1ca4b2-8698-441b-ad5c-e3043a6e6fe7" />

#### 3400K Dark

<img width="3482" height="1896" alt="CleanShot 2026-08-15 at 07 09 22@2x" src="https://github.com/user-attachments/assets/d71b98ad-d1b5-454a-bb66-953514976c7a" />

#### 2000K Dark

<img width="3482" height="1896" alt="CleanShot 2026-08-15 at 07 09 36@2x" src="https://github.com/user-attachments/assets/527705b5-109f-4b6f-a4cc-08f310e2d645" />

#### 1200K Dark

<img width="3482" height="1896" alt="CleanShot 2026-08-15 at 07 09 47@2x" src="https://github.com/user-attachments/assets/82de0935-a949-4e85-9c72-6a2232afef9c" />
